### PR TITLE
add chains to have parity with gas-api

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,25 +49,45 @@ export const writableChains: Record<WritableChainKey, WriteChain> = {
 }
 
 export const readableChains: Record<ReadableChainKey, ReadChain> = {
+	[ReadableChainKey.ARBITRUM]: {
+		chainId: 42161,
+		display: 'Arbitrum'
+	  },
+	[ReadableChainKey.BASE]: {
+		  chainId: 8453,
+		  display: 'Base'
+	  },
+	[ReadableChainKey.BLAST]: {
+		  chainId: 81457,
+		  display: 'Blast'
+	  },
 	[ReadableChainKey.MAIN]: {
 		chainId: 1,
 		display: 'Ethereum'
+	},
+	[ReadableChainKey.FANTOM]: {
+		chainId: 250,
+		display: 'Fantom'
+	},
+	[ReadableChainKey.LINEA]: {
+		chainId: 59144,
+		display: 'Linea'
 	},
 	[ReadableChainKey.OPTIMISM]: {
 		chainId: 10,
 		display: 'Optimism'
 	},
-	// [ReadableChainKey.ARBITRUM]: {
-	//   chainId: 42161,
-	//   display: 'Arbitrum'
-	// },
-	[ReadableChainKey.BASE]: {
-		chainId: 8453,
-		display: 'Base'
-	},
 	[ReadableChainKey.POLYGON]: {
 		chainId: 137,
 		display: 'Polygon'
+	},
+	[ReadableChainKey.SEI]: {
+		chainId: 1329,
+		display: 'SEI'
+	},
+	[ReadableChainKey.ZKSYNC]: {
+		chainId: 324,
+		display: 'zkSync'
 	},
 	[ReadableChainKey.UNSUPPORTED_CHAIN]: {
 		chainId: 1638,

--- a/src/lib/@types/types.ts
+++ b/src/lib/@types/types.ts
@@ -33,11 +33,16 @@ export enum WritableChainKey {
 }
 
 export enum ReadableChainKey {
-  MAIN = 'main',
-  OPTIMISM = 'op',
-  // ARBITRUM = 'arb',
+  ARBITRUM = 'arb',
   BASE = 'base',
+  BLAST = 'blast',
+  MAIN = 'main',
+  FANTOM = 'fantom',
+  LINEA = 'linea',
+  OPTIMISM = 'op',
   POLYGON = 'polygon',
+  SEI = 'sei',
+  ZKSYNC = 'zksync',
   UNSUPPORTED_CHAIN = 'unsupportedChain'
 }
 


### PR DESCRIPTION
This PR adds the following chains and orders them alphabetically to match Gas Extension:
Blast, Fantom, Linea, SEI, zkSync