### PR TITLE
add support for solana/svm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gas-network-client-demo",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"type": "module",
 	"engines": {
 		"node": ">=18.0.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,8 +19,8 @@ export const gasNetwork = {
 export const archSchemaMap: Record<string, number> = {
 	utxo: 1,
 	evm: 2,
-	unsupported: 0,
-	svm: 3
+	svm: 3,
+	unsupported: 0
 }
 
 // You can then create the object that implements this interface:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,7 @@ export const LOCAL_SETTING_KEY = 'bn-gas-demo-settings'
 
 export const utxoV2ContractTypValues = [342]
 export const evmV2ContractTypValues = [107, 322]
+export const svmV2ContractTypValues = [342]
 export const mainnetV2ContractTypValues = [107, 112, 322]
 
 export const gasNetwork = {
@@ -18,7 +19,8 @@ export const gasNetwork = {
 export const archSchemaMap: Record<string, number> = {
 	utxo: 1,
 	evm: 2,
-	unsupported: 0
+	unsupported: 0,
+	svm: 3
 }
 
 // You can then create the object that implements this interface:

--- a/src/lib/@types/types.ts
+++ b/src/lib/@types/types.ts
@@ -51,7 +51,7 @@ export interface PayloadValues {
 export interface ReadChain {
 	chainId: number
 	label: string
-	arch: 'evm' | 'utxo' | 'unsupported'
+	arch: 'evm' | 'utxo' | 'svm' | 'unsupported'
 	v2Supported?: boolean
 	units?: string
   icon?: string

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,8 @@ import {
 	defaultOracleMainnetChain,
 	evmV2ContractTypValues,
 	mainnetV2ContractTypValues,
-	utxoV2ContractTypValues
+	utxoV2ContractTypValues,
+	svmV2ContractTypValues
 } from '../constants'
 import type { EstimationData, OracleChain } from './@types/types'
 
@@ -58,6 +59,8 @@ export const getTypValuesByArch = (arch: number, chainId?: number): number[] => 
 				return mainnetV2ContractTypValues
 			}
 			return evmV2ContractTypValues
+			case 3:
+				return svmV2ContractTypValues
 		default:
 			return []
 	}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -59,8 +59,8 @@ export const getTypValuesByArch = (arch: number, chainId?: number): number[] => 
 				return mainnetV2ContractTypValues
 			}
 			return evmV2ContractTypValues
-			case 3:
-				return svmV2ContractTypValues
+		case 3:
+			return svmV2ContractTypValues
 		default:
 			return []
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -773,6 +773,8 @@
 												<span>{typeof value === 'bigint' ? value.toString() : value} gwei</span>
 											{:else if key.includes('Fee') && selectedReadChain.arch === 'utxo'}
 												<span>{typeof value === 'bigint' ? value.toString() : value} sats</span>
+											{:else if key.includes('Fee') && selectedReadChain.arch === 'svm'}
+												<span>{typeof value === 'bigint' ? value.toString() : value} µlamports</span>
 											{:else}
 												<div>
 													<span>{value}</span>

--- a/src/routes/.well-known/appspecific/com.chrome.devtools.json/+server.ts
+++ b/src/routes/.well-known/appspecific/com.chrome.devtools.json/+server.ts
@@ -1,0 +1,5 @@
+import { json } from '@sveltejs/kit';
+
+export async function GET() {
+	return json({});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1584,9 +1584,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669:
-  version "1.0.30001679"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz#18c573b72f72ba70822194f6c39e7888597f9e32"
-  integrity sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==
+  version "1.0.30001745"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz"
+  integrity sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==
 
 chalk@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
# Overview
This PR adds support for Solana (SVM architecture) to the gas network visualization demo, enabling gas fee estimation and display for Solana-based networks.

## Changes Made

### Type System Updates
- **`src/lib/@types/types.ts`**: Extended `ReadChain.arch` union type to include `'svm'` alongside existing `'evm'`, `'utxo'`, and `'unsupported'` options

### Constants & Configuration
- **`src/constants.ts`**: 
  - Added `svmV2ContractTypValues = [342]` for Solana gas estimation `typ` (P90)
  - Extended `archSchemaMap` to include `svm: 3` mapping

### Utility Functions
- **`src/lib/utils.ts`**: Updated `getTypValuesByArch()` function to handle SVM architecture (case 3) and return appropriate contract `typ` values

### UI & Display
- **`src/routes/+page.svelte`**: Added display logic for SVM gas fees showing values in microlamports (µlamports) units

### Developer Experience
- **`src/routes/.well-known/appspecific/com.chrome.devtools.json/+server.ts`**: Added endpoint to resolve Chrome DevTools 404 errors during development

### Dependencies
- **`yarn.lock`**: Updated caniuse-lite dependency

## Architecture Impact
- Maintains backward compatibility with existing EVM and UTXO chains
- Follows established patterns for architecture support
- Enables future addition of Solana-based networks to the supported chain list

## Testing
✅  No breaking changes to existing functionality (read/write some existing chains)
✅  Read Solana estimate and verify correct display

<img width="665" height="489" alt="Screenshot 2025-09-25 at 10 34 48 AM" src="https://github.com/user-attachments/assets/0b2b3493-46a4-427a-8df3-2d9350b469cf" />

✅  Write Solana estimate and verify transactions completes successfully
https://sepolia.basescan.org/tx/0x70be173258869a651ce3b02d249206816a0b2ba82fd4361aab7e32f7f0490b32
✅  Verify written Solana estimate displays correctly

<img width="683" height="451" alt="Screenshot 2025-09-25 at 10 36 16 AM" src="https://github.com/user-attachments/assets/2593f09c-bd1a-4328-953c-d2b36a076ae8" />
